### PR TITLE
chore: remove visual flicker comment from main.ts

### DIFF
--- a/ma-optimizer-electron/electron/main.ts
+++ b/ma-optimizer-electron/electron/main.ts
@@ -148,7 +148,7 @@ function createWindow() {
         mainWindow.loadFile(path.join(__dirname, '../../dist-vite/index.html'))
     }
 
-    // 🔧 FIX: Show only when ready to eliminate visual flicker/empty window
+
     mainWindow.once('ready-to-show', async () => {
         console.log('[Diagnostic] ready-to-show event triggered.');
         mainWindow?.show()


### PR DESCRIPTION
Removed the comment `// 🔧 FIX: Show only when ready to eliminate visual flicker/empty window` as the implementation is already present.

---
*PR created automatically by Jules for task [1082440876573740630](https://jules.google.com/task/1082440876573740630) started by @Mathiyass*