### PR TITLE
fix(electron): perform sync cleanup of stats polling on quit

### DIFF
--- a/ma-optimizer-electron/electron/ipc/systeminfo.ts
+++ b/ma-optimizer-electron/electron/ipc/systeminfo.ts
@@ -322,3 +322,11 @@ export function startSystemStatsPolling() {
         } catch { }
     }, 2000)
 }
+
+export function stopSystemStatsPolling() {
+    if (systemStatsInterval) {
+        clearInterval(systemStatsInterval)
+        systemStatsInterval = null
+    }
+    isPollingSystemStats = false
+}

--- a/ma-optimizer-electron/electron/main.ts
+++ b/ma-optimizer-electron/electron/main.ts
@@ -18,7 +18,7 @@ import './ipc/benchmark'
 import './ipc/repair'
 import './ipc/advanced'
 import './ipc/driverUpdater'
-import { startSystemStatsPolling } from './ipc/systeminfo'
+import { startSystemStatsPolling, stopSystemStatsPolling } from './ipc/systeminfo'
 
 // 🔧 FIX: Added global exception handler, styled native dialog cannot take CSS colors but we make it clear it's an error.
 process.on('uncaughtException', (error) => {
@@ -346,6 +346,7 @@ app.on('before-quit', () => {
 app.on('will-quit', () => {
     // 🔧 FIX: Unregister all shortcuts or perform sync cleanup here
     try {
+        stopSystemStatsPolling()
         const { globalShortcut } = require('electron')
         globalShortcut.unregisterAll()
     } catch { }


### PR DESCRIPTION
Added `stopSystemStatsPolling` in `systeminfo.ts` to clear the `setInterval` when the app is quitting. This prevents the app from continuing to poll stats while tearing down. Imported and called this cleanup function in `will-quit` inside `main.ts` prior to unregistering global shortcuts.

---
*PR created automatically by Jules for task [3229808037955839933](https://jules.google.com/task/3229808037955839933) started by @Mathiyass*