### PR TITLE
Fix: Dedicated bridge method for create restore point

### DIFF
--- a/ma-optimizer-electron/electron/main.ts
+++ b/ma-optimizer-electron/electron/main.ts
@@ -1,3 +1,4 @@
+import { spawnPromise } from './ipc/utils'
 import { app, BrowserWindow, ipcMain, shell, dialog } from 'electron'
 import * as path from 'path'
 import * as fs from 'fs'
@@ -232,22 +233,14 @@ ipcMain.handle('system:runTool', async (_, cmd: string) => {
     }
 })
 
-// 🔧 FIX: Add dedicated restore point method
 ipcMain.handle('create-restore-point', async () => {
-    return new Promise((resolve) => {
-        const { exec } = require('child_process')
-        // Checks to ensure modifying settings is allowed. Uses elevated child process.
-        exec('powershell.exe -Command "Checkpoint-Computer -Description \'MA Optimizer Restore Point\' -RestorePointType \'MODIFY_SETTINGS\'"',
-            { windowsHide: true },
-            (error: any, stdout: string, stderr: string) => {
-                if (error || stderr) {
-                    console.error('[Restore Point Error]:', error || stderr)
-                    resolve({ success: false, error: error?.message || stderr })
-                } else {
-                    resolve({ success: true })
-                }
-            })
-    })
+    try {
+        await spawnPromise('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', "Checkpoint-Computer -Description 'MA Optimizer Restore Point' -RestorePointType 'MODIFY_SETTINGS'"])
+        return { success: true }
+    } catch (error: any) {
+        console.error('[Restore Point Error]:', error.message || error)
+        return { success: false, error: error.message || String(error) }
+    }
 })
 
 // 🔧 FIX: Fetch Winget app icons via Win32 API / Registry via IPC

--- a/ma-optimizer-electron/electron/preload.ts
+++ b/ma-optimizer-electron/electron/preload.ts
@@ -236,7 +236,6 @@ contextBridge.exposeInMainWorld('api', {
         },
         runMemDiag: () => ipcRenderer.invoke('repair:memdiag'),
     },
-    // 🔧 FIX: Dedicated bridge method for creating a restore point via the header UI button.
     createRestorePoint: () => ipcRenderer.invoke('create-restore-point'),
     advanced: {
         getInstalledApps: () => ipcRenderer.invoke('advanced:getApps'),


### PR DESCRIPTION
Removed the FIX comment in preload.ts and main.ts as the bridge method for create-restore-point is fully implemented. Also refactored the exec call in main.ts to use spawnPromise to prevent shell injection.

---
*PR created automatically by Jules for task [7433439326975706357](https://jules.google.com/task/7433439326975706357) started by @Mathiyass*