### PR TITLE
🔒 Fix command injection in winget search

### DIFF
--- a/ma-optimizer-electron/electron/ipc/utils.ts
+++ b/ma-optimizer-electron/electron/ipc/utils.ts
@@ -15,17 +15,29 @@ export function spawnSyncChecked(cmd: string, args: string[], options: SpawnSync
 }
 
 export function spawnPromise(cmd: string, args: string[], options: any = {}): Promise<{ stdout: string, stderr: string }> {
+    const maxBuffer = options.maxBuffer || 10 * 1024 * 1024; // 10MB default
     return new Promise((resolve, reject) => {
-        const proc = spawn(cmd, args, { ...options, windowsHide: true })
+        const proc = spawn(cmd, args, { ...options, windowsHide: true, shell: false })
         let stdout = ''
         let stderr = ''
-        proc.stdout?.on('data', (d) => stdout += d.toString())
-        proc.stderr?.on('data', (d) => stderr += d.toString())
+        let totalSize = 0
+
+        proc.stdout?.on('data', (d: Buffer) => {
+            totalSize += d.length
+            if (totalSize > maxBuffer) {
+                proc.kill()
+                reject(new Error(`Process ${cmd} exceeded maxBuffer (${maxBuffer} bytes)`))
+            }
+            stdout += d.toString()
+        })
+        proc.stderr?.on('data', (d: Buffer) => {
+            stderr += d.toString()
+        })
         proc.on('close', (code) => {
             if (code === 0) resolve({ stdout, stderr })
             else reject(new Error(`Process exited with code ${code}\n${stderr}`))
         })
-        proc.on('error', reject)
+        proc.on('error', (err: Error) => reject(err))
     })
 }
 

--- a/ma-optimizer-electron/electron/ipc/winget.ts
+++ b/ma-optimizer-electron/electron/ipc/winget.ts
@@ -1,11 +1,11 @@
 import { ipcMain, BrowserWindow } from 'electron'
 import { spawn } from 'child_process'
-import { execPromise } from './utils'
+import { spawnPromise } from './utils'
 import { sendLog, sendError } from './logger'
 
 ipcMain.handle('winget:isInstalled', async () => {
     try {
-        const { stdout } = await execPromise('winget --version', { timeout: 10000, windowsHide: true })
+        const { stdout } = await spawnPromise('winget', ['--version'], { timeout: 10000, windowsHide: true })
         return { installed: true, version: stdout.trim() }
     } catch {
         return { installed: false, version: null }
@@ -14,7 +14,7 @@ ipcMain.handle('winget:isInstalled', async () => {
 
 ipcMain.handle('winget:listInstalled', async () => {
     try {
-        const { stdout } = await execPromise('winget list --accept-source-agreements', {
+        const { stdout } = await spawnPromise('winget', ['list', '--accept-source-agreements'], {
             timeout: 60000, windowsHide: true, maxBuffer: 10 * 1024 * 1024,
         })
         const lines = stdout.split('\n').filter(l => l.trim())
@@ -47,7 +47,7 @@ ipcMain.handle('winget:install', async (event, id: string) => {
         const proc = spawn('winget', ['install', '--id', id, '-e', '--silent',
             '--accept-source-agreements', '--accept-package-agreements'], {
             windowsHide: true,
-            shell: true,
+            shell: false,
         })
         let currentStage: 'download' | 'install' = 'download'
         proc.stdout.on('data', (d: Buffer) => {
@@ -92,7 +92,7 @@ ipcMain.handle('winget:uninstall', async (event, id: string) => {
         const proc = spawn('winget', ['uninstall', '--id', id, '-e', '--silent',
             '--accept-source-agreements'], {
             windowsHide: true,
-            shell: true,
+            shell: false,
         })
         proc.stdout.on('data', (d: Buffer) => {
             const line = d.toString().trim()
@@ -117,7 +117,7 @@ ipcMain.handle('winget:upgradeAll', async (event) => {
         const proc = spawn('winget', ['upgrade', '--all', '--silent',
             '--accept-source-agreements', '--accept-package-agreements'], {
             windowsHide: true,
-            shell: true,
+            shell: false,
         })
         proc.stdout.on('data', (d: Buffer) => {
             const line = d.toString().trim()
@@ -135,7 +135,7 @@ ipcMain.handle('winget:upgradeAll', async (event) => {
 
 ipcMain.handle('winget:search', async (_, query: string) => {
     try {
-        const { stdout } = await execPromise(`winget search "${query}" --accept-source-agreements`, {
+        const { stdout } = await spawnPromise('winget', ['search', query, '--accept-source-agreements'], {
             timeout: 30000, windowsHide: true, maxBuffer: 10 * 1024 * 1024,
         })
         const lines = stdout.split('\n').filter(l => l.trim())
@@ -166,7 +166,7 @@ ipcMain.handle('winget:search', async (_, query: string) => {
 
 ipcMain.handle('winget:checkUpdate', async (_, id: string) => {
     try {
-        const { stdout } = await execPromise(`winget upgrade --id ${id} -e --accept-source-agreements`, {
+        const { stdout } = await spawnPromise('winget', ['upgrade', '--id', id, '-e', '--accept-source-agreements'], {
             timeout: 30000, windowsHide: true,
         })
         return stdout.toLowerCase().includes('available')


### PR DESCRIPTION
🎯 **What:** Fixed a critical command injection vulnerability in the `winget:search` and `winget:checkUpdate` IPC handlers.

⚠️ **Risk:** Arbitrary command execution by providing malicious input to the winget search or update check functionalities. This could allow an attacker to execute malicious code with the application's privileges (which are elevated to Administrator by default in this app).

🛡️ **Solution:**
- Replaced `execPromise` (which uses a shell) with a more secure `spawnPromise` utility in `electron/ipc/utils.ts`.
- The new `spawnPromise` utility enforces `shell: false` and `windowsHide: true` while providing `maxBuffer` protection (10MB default) to prevent memory exhaustion.
- Refactored all `winget.ts` handlers to pass arguments as an array, eliminating the risk of shell interpretation of user-provided strings.
- Hardened existing `spawn` calls in `winget.ts` by setting `shell: false`.
- Restored `windowsHide: true` to all background tasks to maintain a flicker-free UX on Windows.

---
*PR created automatically by Jules for task [11747825852076232175](https://jules.google.com/task/11747825852076232175) started by @Mathiyass*