### PR TITLE
⚡ Refactor backup and registry IPC handlers to use asynchronous file I/O

### DIFF
--- a/ma-optimizer-electron/electron/ipc/backup.ts
+++ b/ma-optimizer-electron/electron/ipc/backup.ts
@@ -8,18 +8,18 @@ import { escapePS, spawnSyncChecked } from './utils'
 
 const backupDir = path.join(app.getPath('userData'), 'backups')
 
-function ensureDir(dir: string) {
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+async function ensureDir(dir: string) {
+    if (!fs.existsSync(dir)) await fs.promises.mkdir(dir, { recursive: true })
 }
 
 // Export all MA-Optimizer settings as .maopt JSON
 ipcMain.handle('backup:export', async (_, savePath: string) => {
     try {
-        ensureDir(path.dirname(savePath))
+        await ensureDir(path.dirname(savePath))
         const data = {
             version: '7.0.0',
             exportedAt: new Date().toISOString(),
-            registryBackups: loadBackups(),
+            registryBackups: await loadBackups(),
             appliedTweaks: {},
         }
         // Also include electron-store settings
@@ -28,7 +28,7 @@ ipcMain.handle('backup:export', async (_, savePath: string) => {
             const store = new Store()
             data.appliedTweaks = store.get('appliedTweaks') || {}
         } catch { }
-        fs.writeFileSync(savePath, JSON.stringify(data, null, 2), 'utf-8')
+        await fs.promises.writeFile(savePath, JSON.stringify(data, null, 2), 'utf-8')
         sendLog(`[Backup] Exported settings to ${savePath}`)
         return { success: true }
     } catch (e: any) {
@@ -40,7 +40,7 @@ ipcMain.handle('backup:export', async (_, savePath: string) => {
 // Import settings from .maopt JSON
 ipcMain.handle('backup:import', async (_, filePath: string) => {
     try {
-        const raw = fs.readFileSync(filePath, 'utf-8')
+        const raw = await fs.promises.readFile(filePath, 'utf-8')
         const data = JSON.parse(raw)
         if (!data.version) {
             return { success: false, error: 'Invalid backup file' }
@@ -63,7 +63,7 @@ ipcMain.handle('backup:import', async (_, filePath: string) => {
 
 // Undo all changes — restores all original registry values
 ipcMain.handle('backup:undoAll', async () => {
-    const backups = loadBackups()
+    const backups = await loadBackups()
     let restored = 0
     let failed = 0
 
@@ -90,7 +90,7 @@ ipcMain.handle('backup:undoAll', async () => {
 
 // Undo last change only
 ipcMain.handle('backup:undoLast', async () => {
-    const backups = loadBackups()
+    const backups = await loadBackups()
     const entries = Object.entries(backups)
     if (entries.length === 0) return { success: false, error: 'No changes to undo' }
 
@@ -110,10 +110,10 @@ ipcMain.handle('backup:undoLast', async () => {
             })
         }
         // Remove this entry from backups
-        const allBackups = loadBackups()
+        const allBackups = await loadBackups()
         delete allBackups[key]
         const backupPath = path.join(app.getPath('userData'), 'backups', 'registry_backup.json')
-        fs.writeFileSync(backupPath, JSON.stringify(allBackups, null, 2), 'utf-8')
+        await fs.promises.writeFile(backupPath, JSON.stringify(allBackups, null, 2), 'utf-8')
         sendLog(`[Backup] Undone last change: ${key}`)
         return { success: true, key }
     } catch (e: any) {

--- a/ma-optimizer-electron/electron/ipc/registry.ts
+++ b/ma-optimizer-electron/electron/ipc/registry.ts
@@ -27,31 +27,32 @@ async function ensureRestorePoint() {
 
 const backupPath = path.join(app.getPath('userData'), 'backups', 'registry_backup.json')
 
-function ensureBackupDir() {
+async function ensureBackupDir() {
     const dir = path.dirname(backupPath)
     if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir, { recursive: true })
+        await fs.promises.mkdir(dir, { recursive: true })
     }
 }
 
-function loadBackups(): Record<string, any> {
-    ensureBackupDir()
+export async function loadBackups(): Promise<Record<string, any>> {
+    await ensureBackupDir()
     try {
         if (fs.existsSync(backupPath)) {
-            return JSON.parse(fs.readFileSync(backupPath, 'utf-8'))
+            const data = await fs.promises.readFile(backupPath, 'utf-8')
+            return JSON.parse(data)
         }
     } catch { }
     return {}
 }
 
-function saveBackups(data: Record<string, any>) {
-    ensureBackupDir()
-    fs.writeFileSync(backupPath, JSON.stringify(data, null, 2), 'utf-8')
+export async function saveBackups(data: Record<string, any>) {
+    await ensureBackupDir()
+    await fs.promises.writeFile(backupPath, JSON.stringify(data, null, 2), 'utf-8')
 }
 
-function backupOriginalValue(hive: string, regPath: string, name: string, currentValue: any) {
+export async function backupOriginalValue(hive: string, regPath: string, name: string, currentValue: any) {
     const key = `${hive}\\${regPath}\\${name}`
-    const backups = loadBackups()
+    const backups = await loadBackups()
     // Never overwrite an existing backup for the same key
     if (!(key in backups)) {
         backups[key] = {
@@ -61,7 +62,7 @@ function backupOriginalValue(hive: string, regPath: string, name: string, curren
             originalValue: currentValue,
             backedUpAt: new Date().toISOString(),
         }
-        saveBackups(backups)
+        await saveBackups(backups)
         sendLog(`[Backup] Saved original value for ${key}: ${currentValue}`)
     }
 }
@@ -104,7 +105,7 @@ ipcMain.handle('registry:set', async (_, hive: string, regPath: string, name: st
         } catch { }
 
         // Backup original value
-        backupOriginalValue(hive, regPath, name, currentValue)
+        await backupOriginalValue(hive, regPath, name, currentValue)
 
         // Map type names
         const typeMap: Record<string, string> = {
@@ -156,12 +157,12 @@ ipcMain.handle('registry:delete', async (_, hive: string, regPath: string, name:
 
 // Full registry backup export
 ipcMain.handle('registry:backup', async () => {
-    return loadBackups()
+    return await loadBackups()
 })
 
 // Restore all backed up values
 ipcMain.handle('registry:restoreAll', async () => {
-    const backups = loadBackups()
+    const backups = await loadBackups()
     let restored = 0
     for (const [key, entry] of Object.entries(backups)) {
         try {
@@ -185,7 +186,7 @@ ipcMain.handle('registry:restoreAll', async () => {
 
 // Restore last backed up value
 ipcMain.handle('registry:restoreLast', async () => {
-    const backups = loadBackups()
+    const backups = await loadBackups()
     const entries = Object.entries(backups)
     if (entries.length === 0) return { success: false, error: 'No backups found' }
 
@@ -207,7 +208,7 @@ ipcMain.handle('registry:restoreLast', async () => {
         }
         // Remove from backups
         delete backups[key]
-        saveBackups(backups)
+        await saveBackups(backups)
         sendLog(`[Registry] Restored last change: ${key}`)
         return { success: true, key }
     } catch (e: any) {
@@ -216,4 +217,3 @@ ipcMain.handle('registry:restoreLast', async () => {
     }
 })
 
-export { backupOriginalValue, loadBackups }


### PR DESCRIPTION
This PR optimizes the performance of the Electron main process by refactoring synchronous file system operations into asynchronous ones within the backup and registry IPC handlers. 

### 💡 What
- Switched from synchronous `fs` methods (`readFileSync`, `writeFileSync`, `mkdirSync`) to their promise-based counterparts in `fs.promises`.
- Converted internal utility functions in `registry.ts` (`loadBackups`, `saveBackups`, `backupOriginalValue`) to `async` functions.
- Corrected module exports and imports to support the new asynchronous signatures.

### 🎯 Why
Synchronous file I/O in the Electron main process blocks the event loop, which can lead to UI "freezes" or lag while the application reads or writes backup data. Moving these operations to an asynchronous model allows the main process to remain responsive to other IPC events and system tasks.

### 📊 Measured Improvement
While specific micro-benchmarks in the restricted sandbox environment showed minimal measurable lag for small test files, transitioning to asynchronous I/O is a well-established best practice for Electron applications to maintain UI fluidity, especially when dealing with potentially large JSON backup files on slower storage media. This refactor ensures that the application's responsiveness is not tied to the speed of the underlying file system.

---
*PR created automatically by Jules for task [9646370616879115410](https://jules.google.com/task/9646370616879115410) started by @Mathiyass*