### PR TITLE
🔒 [security fix] Remove insecure 'unsafe-eval' from CSP

### DIFF
--- a/ma-optimizer-electron/electron/main.ts
+++ b/ma-optimizer-electron/electron/main.ts
@@ -315,7 +315,7 @@ app.whenReady().then(async () => {
         callback({
             responseHeaders: {
                 ...details.responseHeaders,
-                'Content-Security-Policy': ["default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' http://localhost:* ws://localhost:* https://logo.clearbit.com https://icons.duckduckgo.com"]
+                'Content-Security-Policy': ["default-src 'self' 'unsafe-inline' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' http://localhost:* ws://localhost:* https://logo.clearbit.com https://icons.duckduckgo.com"]
             }
         })
     })


### PR DESCRIPTION
Removed 'unsafe-eval' from the Content-Security-Policy header in `ma-optimizer-electron/electron/main.ts` to improve the application's security posture against XSS attacks. Verified that no dynamic evaluation is used in the codebase.

---
*PR created automatically by Jules for task [7982427263510774877](https://jules.google.com/task/7982427263510774877) started by @Mathiyass*