### PR TITLE
🔒 [security fix] Remove 'unsafe-eval' from Content-Security-Policy

### DIFF
--- a/ma-optimizer-electron/electron/main.ts
+++ b/ma-optimizer-electron/electron/main.ts
@@ -315,7 +315,7 @@ app.whenReady().then(async () => {
         callback({
             responseHeaders: {
                 ...details.responseHeaders,
-                'Content-Security-Policy': ["default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' http://localhost:* ws://localhost:* https://logo.clearbit.com https://icons.duckduckgo.com"]
+                'Content-Security-Policy': ["default-src 'self' 'unsafe-inline' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' http://localhost:* ws://localhost:* https://logo.clearbit.com https://icons.duckduckgo.com"]
             }
         })
     })


### PR DESCRIPTION
This PR addresses a security vulnerability by removing the `'unsafe-eval'` directive from the application's `Content-Security-Policy`.

🎯 **What:** The vulnerability fixed is an insecure CSP that allowed the use of `eval()` and `new Function()`.
⚠️ **Risk:** If left unfixed, an attacker could potentially exploit an XSS vulnerability to execute arbitrary code within the renderer process, increasing the application's attack surface.
🛡️ **Solution:** The fix involves updating the `onHeadersReceived` handler in the Electron main process (`ma-optimizer-electron/electron/main.ts`) to provide a more restrictive CSP that excludes `'unsafe-eval'`.

Verification included:
- Code inspection to confirm removal of the directive.
- Running available unit tests (core utilities passed; some store tests failed due to sandbox-specific dependency issues unrelated to this change).
- Code review confirmed the fix is correct and follows best practices.

---
*PR created automatically by Jules for task [6743658414885354458](https://jules.google.com/task/6743658414885354458) started by @Mathiyass*