### PR TITLE
🧪 Add tests for logStore

### DIFF
--- a/ma-optimizer-electron/src/store/logStore.test.ts
+++ b/ma-optimizer-electron/src/store/logStore.test.ts
@@ -1,0 +1,57 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { useLogStore } from './logStore.ts';
+
+test('logStore - initial state', () => {
+    useLogStore.getState().clear();
+    const state = useLogStore.getState();
+    assert.strictEqual(state.lines.length, 0);
+    assert.strictEqual(state.nextId, 1);
+});
+
+test('logStore - addLine', () => {
+    useLogStore.getState().clear();
+    const { addLine } = useLogStore.getState();
+
+    addLine('Test log 1');
+    let state = useLogStore.getState();
+    assert.strictEqual(state.lines.length, 1);
+    assert.strictEqual(state.lines[0].text, 'Test log 1');
+    assert.strictEqual(state.lines[0].id, 1);
+    assert.strictEqual(state.nextId, 2);
+    assert.match(state.lines[0].timestamp, /^\d{2}:\d{2}:\d{2}$/);
+
+    addLine('Test log 2');
+    state = useLogStore.getState();
+    assert.strictEqual(state.lines.length, 2);
+    assert.strictEqual(state.lines[1].text, 'Test log 2');
+    assert.strictEqual(state.lines[1].id, 2);
+    assert.strictEqual(state.nextId, 3);
+});
+
+test('logStore - clear', () => {
+    const { addLine, clear } = useLogStore.getState();
+    addLine('Log to be cleared');
+    clear();
+
+    const state = useLogStore.getState();
+    assert.strictEqual(state.lines.length, 0);
+    assert.strictEqual(state.nextId, 1);
+});
+
+test('logStore - 1000 line limit', () => {
+    useLogStore.getState().clear();
+    const { addLine } = useLogStore.getState();
+
+    // Add 1001 lines
+    for (let i = 1; i <= 1001; i++) {
+        addLine(`Log ${i}`);
+    }
+
+    const state = useLogStore.getState();
+    assert.strictEqual(state.lines.length, 1000);
+    // Should contain logs from 2 to 1001
+    assert.strictEqual(state.lines[0].text, 'Log 2');
+    assert.strictEqual(state.lines[999].text, 'Log 1001');
+    assert.strictEqual(state.nextId, 1002);
+});


### PR DESCRIPTION
This PR adds unit tests for the `logStore` in the Electron application. 

### 🎯 What: The testing gap addressed
The `useLogStore` was missing automated tests for its core logic, specifically the line addition and the 1000-item buffer limit.

### 📊 Coverage: What scenarios are now tested
- **Initial State**: Confirmed the store starts empty with `nextId` at 1.
- **Add Line**: Verified that `addLine` correctly appends to the `lines` array, increments `nextId`, and generates a valid HH:mm:ss timestamp.
- **Clear**: Confirmed the `clear` action resets the store.
- **1000 Line Limit**: Added a test that inserts 1001 lines and verifies that the store only keeps the last 1000, following a First-In-First-Out (FIFO) pattern.

### ✨ Result: The improvement in test coverage
Increased test coverage for the store layer, ensuring that the logging system behaves predictably and manages memory correctly by capping the number of stored log entries.

---
*PR created automatically by Jules for task [16916375618130110876](https://jules.google.com/task/16916375618130110876) started by @Mathiyass*