### PR TITLE
🔒 Fix Command Injection in advanced:bcdedit

### DIFF
--- a/ma-optimizer-electron/electron/ipc/advanced.ts
+++ b/ma-optimizer-electron/electron/ipc/advanced.ts
@@ -86,17 +86,31 @@ ipcMain.handle('advanced:toggleFeature', async (_, name: string, enable: boolean
 })
 
 // BCDedit
-ipcMain.handle('advanced:bcdedit', async (_, args: string) => {
+ipcMain.handle('advanced:bcdedit', async (_, args: string[]) => {
     try {
-        // Since bcdedit doesn't have a stable list of subcommands I can whitelist,
-        // and it is a string from renderer, I should at least use spawnSync to avoid shell injection.
-        // But bcdedit args can be multiple.
-        const argArray = String(args).split(' ').filter(a => a.trim())
-        const { stdout } = spawnSyncChecked('bcdedit', argArray, {
+        if (!Array.isArray(args) || args.length === 0) {
+            throw new Error('Invalid arguments: expected non-empty array')
+        }
+
+        // Restrict to informational subcommands only to prevent unauthorized system changes
+        const allowedSubcommands = ['/enum', '/v', '/get']
+        if (!allowedSubcommands.includes(args[0].toLowerCase())) {
+            throw new Error(`Unauthorized bcdedit subcommand: ${args[0]}`)
+        }
+
+        // Regex to ensure arguments only contain safe characters
+        const safeRegex = /^[a-zA-Z0-9\s\/\-\{\}\.]+$/
+        for (const arg of args) {
+            if (!safeRegex.test(arg)) {
+                throw new Error(`Invalid characters in argument: ${arg}`)
+            }
+        }
+
+        const { stdout } = spawnSyncChecked('bcdedit', args, {
             encoding: 'utf-8', timeout: 10000,
         })
         const result = stdout.trim()
-        sendLog(`[Advanced] bcdedit ${args}`)
+        sendLog(`[Advanced] bcdedit ${args.join(' ')}`)
         return result
     } catch (e: any) {
         sendError(`bcdedit failed: ${e.message}`)

--- a/ma-optimizer-electron/electron/preload.ts
+++ b/ma-optimizer-electron/electron/preload.ts
@@ -248,8 +248,8 @@ contextBridge.exposeInMainWorld('api', {
             validate([name, enable], ['string', 'boolean'])
             return ipcRenderer.invoke('advanced:toggleFeature', name, enable)
         },
-        runBcdedit: (args: string) => {
-            validate([args], ['string'])
+        runBcdedit: (args: string[]) => {
+            validate([args], ['array'])
             return ipcRenderer.invoke('advanced:bcdedit', args)
         },
         enableGodMode: () => ipcRenderer.invoke('advanced:godMode'),

--- a/ma-optimizer-electron/src/window.d.ts
+++ b/ma-optimizer-electron/src/window.d.ts
@@ -109,7 +109,7 @@ export interface WindowApi {
         removeApps: (names: string[]) => Promise<{ removed: number; total: number }>
         getWindowsFeatures: () => Promise<Array<{ name: string; enabled: boolean }>>
         toggleFeature: (name: string, enable: boolean) => Promise<boolean>
-        runBcdedit: (args: string) => Promise<string | null>
+        runBcdedit: (args: string[]) => Promise<string | null>
         enableGodMode: () => Promise<boolean>
         changeComputerName: (name: string) => Promise<boolean>
     }


### PR DESCRIPTION
This pull request fixes a security vulnerability in the `advanced:bcdedit` IPC handler where unsanitized user input was being passed to a system command.

🎯 **What:** The `bcdedit` IPC handler now accepts an array of strings instead of a single string, eliminating brittle space-based splitting.
⚠️ **Risk:** Previously, a compromised renderer could have executed arbitrary `bcdedit` commands with administrative privileges, potentially disabling security features or making the system unbootable.
🛡️ **Solution:**
- Moved to an array-based argument passing method.
- Implemented a strict whitelist of subcommands, restricting usage to informational commands (`/enum`, `/v`, `/get`).
- Added a regular expression validation step to ensure all arguments contain only safe, expected characters.
- Updated the preload bridge and TypeScript definitions to ensure consistency.

Since `runBcdedit` was currently unused in the renderer codebase, this fix proactively secures the API before it is integrated into the UI.

---
*PR created automatically by Jules for task [12302089060706791649](https://jules.google.com/task/12302089060706791649) started by @Mathiyass*