### PR TITLE
fix: Remove completed task comment for app setup before ipc handler imports

### DIFF
--- a/ma-optimizer-electron/electron/main.ts
+++ b/ma-optimizer-electron/electron/main.ts
@@ -4,8 +4,6 @@ import * as fs from 'fs'
 
 const isDev = process.env.NODE_ENV === 'development'
 
-// 🔧 FIX: app.setPath('userData', ...) and app.commandLine.appendSwitch must be called before any IPC handler imports
-// to ensure that custom user data paths (used by logger) and Chromium switches are applied correctly.
 app.setPath('userData', path.join(app.getPath('appData'), 'MA-Optimizer'))
 app.commandLine.appendSwitch('disable-features', 'AutofillServerCommunication')
 


### PR DESCRIPTION
Removed the `// 🔧 FIX: app.setPath('userData', ...) and app.commandLine.appendSwitch must be called before any IPC handler imports` comment and its succeeding line from `ma-optimizer-electron/electron/main.ts` since the refactoring is already present in the codebase. Tests were verified to be passing.

---
*PR created automatically by Jules for task [16927376111885824672](https://jules.google.com/task/16927376111885824672) started by @Mathiyass*