### PR TITLE
Remove unused system stat polling IPC handlers

### DIFF
--- a/ma-optimizer-electron/electron/ipc/systeminfo.ts
+++ b/ma-optimizer-electron/electron/ipc/systeminfo.ts
@@ -9,30 +9,6 @@ function getSi() {
     return si
 }
 
-ipcMain.handle('system:cpuUsage', async () => {
-    try {
-        const load = await getSi().currentLoad()
-        return {
-            currentLoad: Math.round(load.currentLoad * 10) / 10,
-            cpus: load.cpus?.map((c: any) => Math.round(c.load * 10) / 10) || [],
-        }
-    } catch { return { currentLoad: 0, cpus: [] } }
-})
-
-ipcMain.handle('system:ramUsage', async () => {
-    try {
-        const mem = await getSi().mem()
-        return {
-            total: mem.total,
-            used: mem.active,
-            free: mem.available,
-            usedPercent: Math.round((mem.active / mem.total) * 1000) / 10,
-            swapTotal: mem.swaptotal,
-            swapUsed: mem.swapused,
-        }
-    } catch { return { total: 0, used: 0, free: 0, usedPercent: 0, swapTotal: 0, swapUsed: 0 } }
-})
-
 let diskIOMetrics = { readBytesPerSec: 0, writeBytesPerSec: 0 }
 
 function startTypeperfDiskIO() {
@@ -61,51 +37,6 @@ function startTypeperfDiskIO() {
 }
 
 startTypeperfDiskIO()
-
-// Use fsStats / Typeperf for reliable byte-rate data on Windows (disksIO often returns 0)
-ipcMain.handle('system:diskIO', async () => {
-    try {
-        if (process.platform === 'win32') {
-            return {
-                readPerSec: diskIOMetrics.readBytesPerSec,
-                writePerSec: diskIOMetrics.writeBytesPerSec,
-                readBytesPerSec: diskIOMetrics.readBytesPerSec,
-                writeBytesPerSec: diskIOMetrics.writeBytesPerSec,
-            }
-        }
-
-        const fs = await getSi().fsStats()
-        if (fs && (fs.rx_sec !== null || fs.wx_sec !== null)) {
-            return {
-                readPerSec: fs.rx_sec || 0,
-                writePerSec: fs.wx_sec || 0,
-                readBytesPerSec: fs.rx_sec || 0,
-                writeBytesPerSec: fs.wx_sec || 0,
-            }
-        }
-        // Fallback to disksIO
-        const io = await getSi().disksIO()
-        return {
-            readPerSec: io?.rIO_sec || 0,
-            writePerSec: io?.wIO_sec || 0,
-            readBytesPerSec: io?.rIO_sec || 0,
-            writeBytesPerSec: io?.wIO_sec || 0,
-        }
-    } catch { return { readPerSec: 0, writePerSec: 0, readBytesPerSec: 0, writeBytesPerSec: 0 } }
-})
-
-ipcMain.handle('system:networkSpeed', async () => {
-    try {
-        const net = await getSi().networkStats()
-        const primary = net[0] || {}
-        return {
-            rxSec: primary.rx_sec || 0,
-            txSec: primary.tx_sec || 0,
-            rxBytes: primary.rx_bytes || 0,
-            txBytes: primary.tx_bytes || 0,
-        }
-    } catch { return { rxSec: 0, txSec: 0, rxBytes: 0, txBytes: 0 } }
-})
 
 ipcMain.handle('system:fullInfo', async () => {
     try {

--- a/ma-optimizer-electron/electron/preload.ts
+++ b/ma-optimizer-electron/electron/preload.ts
@@ -67,10 +67,6 @@ contextBridge.exposeInMainWorld('api', {
         delete: () => ipcRenderer.invoke('powerplan:delete'),
     },
     system: {
-        getCpuUsage: () => ipcRenderer.invoke('system:cpuUsage'),
-        getRamUsage: () => ipcRenderer.invoke('system:ramUsage'),
-        getDiskIO: () => ipcRenderer.invoke('system:diskIO'),
-        getNetworkSpeed: () => ipcRenderer.invoke('system:networkSpeed'),
         getFullInfo: () => ipcRenderer.invoke('system:fullInfo'),
         getProcesses: () => ipcRenderer.invoke('system:processes'),
         killProcess: (pid: number) => {

--- a/ma-optimizer-electron/src/window.d.ts
+++ b/ma-optimizer-electron/src/window.d.ts
@@ -27,10 +27,6 @@ export interface WindowApi {
         delete: () => Promise<boolean>
     }
     system: {
-        getCpuUsage: () => Promise<{ currentLoad: number; cpus: number[] }>
-        getRamUsage: () => Promise<{ total: number; used: number; free: number; usedPercent: number; swapTotal: number; swapUsed: number }>
-        getDiskIO: () => Promise<{ readPerSec: number; writePerSec: number; readBytesPerSec: number; writeBytesPerSec: number }>
-        getNetworkSpeed: () => Promise<{ rxSec: number; txSec: number; rxBytes: number; txBytes: number }>
         getFullInfo: () => Promise<any>
         getProcesses: () => Promise<any[]>
         killProcess: (pid: number) => Promise<boolean>


### PR DESCRIPTION
Removed unused individual system stat polling IPC handlers (`system:cpuUsage`, `system:ramUsage`, `system:diskIO`, `system:networkSpeed`) from `electron/ipc/systeminfo.ts` and their corresponding bindings in `electron/preload.ts` and `src/window.d.ts`, completing the centralization to the main process pushing stats to the renderer.

---
*PR created automatically by Jules for task [12121168529168607375](https://jules.google.com/task/12121168529168607375) started by @Mathiyass*